### PR TITLE
fix: correctly mark cjs exports as commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/well-known-parser.es.js",
-      "require": "./dist/well-known-parser.cjs.js",
-      "default": "./dist/well-known-parser.umd.js"
+      "import": "./dist/well-known-parser.js",
+      "require": "./dist/well-known-parser.cjs"
     }
   },
   "files": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'wkx',
-      fileName: (format) => `well-known-parser.${format}.js`,
-      formats: ['es', 'cjs', ]
+      fileName: (format) => `well-known-parser.${format === "cjs" ? "cjs" : "js"}`,
+      formats: ['es', 'cjs']
     },
     outDir: 'dist',
     rollupOptions: {


### PR DESCRIPTION
Any exported js file will be treated as esm if the package json sets type module. This changes the file extension used for the commonjs build to cjs to mark the files correctly as commonjs